### PR TITLE
fix(auth): parse and map Apple user form data on first login

### DIFF
--- a/internal/auth/auth_handler.go
+++ b/internal/auth/auth_handler.go
@@ -129,7 +129,6 @@ func (a *Auth) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var appleData appleUserJSON
-	a.logger.Info("apple user payload", slog.Any("user", r.FormValue("user")))
 	if provider == "apple" && r.FormValue("user") != "" {
 		if err := json.Unmarshal([]byte(r.FormValue("user")), &appleData); err != nil {
 			a.logger.Warn("Failed to unmarshal apple user form", "error", err)


### PR DESCRIPTION
Implemented manual unmarshaling of the 'user' JSON form field sent by Apple during the initial OAuth callback. This ensures FirstName and LastName are captured and stored, satisfying App Store Guideline 4.0 by removing the need for manual profile entry.

- Added appleUserForm struct for JSON mapping
- Patched goth.User fields before account creation
- Added default name fallback to prevent blank database records

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Apple sign-in now fills in missing first and/or last names from Apple-provided profile data, ensuring newly created or linked accounts display the correct user name.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->