### PR TITLE
Fix double JSON encoding in storeAuthCode function

### DIFF
--- a/internal/auth/auth_handler.go
+++ b/internal/auth/auth_handler.go
@@ -138,16 +138,16 @@ func (h *AuthHandler) storeAuthCode(
 	code string,
 	pair *tokens.TokenPair,
 ) error {
-	val, err := json.Marshal(tokenResponse{
-		AccessToken:      pair.AccessToken,
-		RefreshToken:     pair.RawRefreshToken,
-		AccessExpiresAt:  pair.AccessExpiresAt,
-		RefreshExpiresAt: pair.RefreshExpiresAt,
-	})
-	if err != nil {
-		return err
-	}
-	return h.cacher.Set(ctx, authCodePrefix+code, string(val), authCodeTTL)
+	return h.cacher.Set(
+		ctx, authCodePrefix+code,
+		tokenResponse{
+			AccessToken:      pair.AccessToken,
+			RefreshToken:     pair.RawRefreshToken,
+			AccessExpiresAt:  pair.AccessExpiresAt,
+			RefreshExpiresAt: pair.RefreshExpiresAt,
+		},
+		authCodeTTL,
+	)
 }
 
 func (h *AuthHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Pass tokenResponse struct directly to cacher.Set instead of pre-marshalling to JSON and converting to string. The cacher handles serialisation internally, causing the value to be encoded twice and auth code exchange to always fail.