### PR TITLE
fix(tokens): correct token expiry duration unit conversion

### DIFF
--- a/internal/tokens/token_service.go
+++ b/internal/tokens/token_service.go
@@ -48,11 +48,10 @@ func (ts tokenService) IssueTokenPair(
 	}
 
 	accessExpiry := time.Now().
-		Add(time.Duration(ts.config.JWTConfig.ExpireDelta))
+		Add(time.Duration(ts.config.JWTConfig.ExpireDelta) * time.Minute)
 
-	refreshExpiry := time.Now().Add(
-		time.Duration(ts.config.JWTConfig.RefreshExpireDelta),
-	)
+	refreshExpiry := time.Now().
+		AddDate(0, 0, int(ts.config.JWTConfig.RefreshExpireDelta))
 
 	accessToken, err := ts.signJwt(jti, userID, accessExpiry)
 	if err != nil {


### PR DESCRIPTION
ExpireDelta and RefreshExpireDelta were cast to time.Duration directly, treating the values as nanoseconds instead of the intended units. Access tokens now multiply by time.Minute and refresh tokens by 24*time.Hour, causing both to expire almost immediately after issue.