### PR TITLE
refactor: standardize HTTP error responses via core.HandleError

### DIFF
--- a/internal/auth/auth_handler.go
+++ b/internal/auth/auth_handler.go
@@ -154,7 +154,7 @@ func (h *AuthHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 	provider, err := GetProviderName(r)
 	if err != nil {
 		h.logger.Warn("missing provider in login request", "error", err)
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		core.WriteError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -165,10 +165,10 @@ func (h *AuthHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 		platform = authPlatformWebValue
 		redirectURI = r.URL.Query().Get("redirect_uri")
 		if redirectURI == "" {
-			http.Error(
+			core.WriteError(
 				w,
-				"missing redirect_uri for web platform",
 				http.StatusBadRequest,
+				"missing redirect_uri for web platform",
 			)
 			return
 		}
@@ -177,7 +177,7 @@ func (h *AuthHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 			redirectURI,
 			h.auth.config.JWTConfig.AllowedRedirectURIs,
 		) {
-			http.Error(w, "redirect_uri not allowed", http.StatusBadRequest)
+			core.WriteError(w, http.StatusBadRequest, "redirect_uri not allowed")
 			return
 		}
 	}
@@ -203,10 +203,10 @@ func (h *AuthHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 	url, err := gothic.GetAuthURL(w, r)
 	if err != nil {
 		h.logger.Error("failed to get auth URL from provider", "error", err)
-		http.Error(
+		core.WriteError(
 			w,
-			"failed to initiate login",
 			http.StatusInternalServerError,
+			"failed to initiate login",
 		)
 		return
 	}
@@ -218,7 +218,7 @@ func (h *AuthHandler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodPost {
 		if err := r.ParseForm(); err != nil {
 			h.logger.Error("failed to parse Apple callback form", "error", err)
-			http.Error(w, "invalid request", http.StatusBadRequest)
+			core.WriteError(w, http.StatusBadRequest, "invalid request")
 			return
 		}
 	}
@@ -226,20 +226,20 @@ func (h *AuthHandler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	provider, err := GetProviderName(r)
 	if err != nil {
 		h.logger.Warn("missing provider in callback", "error", err)
-		http.Error(w, "missing provider", http.StatusBadRequest)
+		core.WriteError(w, http.StatusBadRequest, "missing provider")
 		return
 	}
 
 	stateData, err := decodeState(r)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		core.WriteError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
 	gothUser, err := gothic.CompleteUserAuth(w, r)
 	if err != nil {
 		h.logger.Error("OAuth flow failed", slog.Any("error", err))
-		http.Error(w, "authentication failed", http.StatusInternalServerError)
+		core.WriteError(w, http.StatusInternalServerError, "authentication failed")
 		return
 	}
 
@@ -253,7 +253,7 @@ func (h *AuthHandler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 			"failed to acquire DB connection",
 			slog.Any("error", err),
 		)
-		http.Error(w, "database error", http.StatusInternalServerError)
+		core.WriteError(w, http.StatusInternalServerError, "database error")
 		return
 	}
 
@@ -329,7 +329,7 @@ func (h *AuthHandler) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		h.logger.Error("callback transaction failed", slog.Any("error", err))
-		http.Error(w, "authentication failed", http.StatusInternalServerError)
+		core.WriteError(w, http.StatusInternalServerError, "authentication failed")
 		return
 	}
 
@@ -455,7 +455,7 @@ func (h *AuthHandler) LogoutHandler(w http.ResponseWriter, r *http.Request) {
 	provider, err := GetProviderName(r)
 	if err != nil {
 		h.logger.Warn("missing provider in logout request", "error", err)
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		core.WriteError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -465,7 +465,7 @@ func (h *AuthHandler) LogoutHandler(w http.ResponseWriter, r *http.Request) {
 			slog.String("provider", provider),
 			slog.Any("error", err),
 		)
-		http.Error(w, "logout failed", http.StatusInternalServerError)
+		core.WriteError(w, http.StatusInternalServerError, "logout failed")
 		return
 	}
 
@@ -629,13 +629,13 @@ func (h *AuthHandler) handleMobileCallback(
 	code, err := generateOpaqueCode()
 	if err != nil {
 		h.logger.Error("failed to generate auth code", slog.Any("error", err))
-		http.Error(w, "authentication failed", http.StatusInternalServerError)
+		core.WriteError(w, http.StatusInternalServerError, "authentication failed")
 		return
 	}
 
 	if err := h.storeAuthCode(r.Context(), code, pair); err != nil {
 		h.logger.Error("failed to store auth code", slog.Any("error", err))
-		http.Error(w, "authentication failed", http.StatusInternalServerError)
+		core.WriteError(w, http.StatusInternalServerError, "authentication failed")
 		return
 	}
 

--- a/internal/core/http_error.go
+++ b/internal/core/http_error.go
@@ -1,0 +1,38 @@
+package core
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+)
+
+// WriteJSON writes body as a JSON response with the given status code.
+func WriteJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(body)
+}
+
+// WriteError writes an APIError{Error: message} JSON response with the given
+// status code. Prefer HandleError when you have a domain error to map from a
+// sentinel (ErrInvalidInput, etc.) rather than an already-chosen status code.
+func WriteError(w http.ResponseWriter, status int, message string) {
+	WriteJSON(w, status, APIError{Error: message})
+}
+
+// HandleError maps a domain error to an HTTP response by checking it against
+// the sentinel errors below. Add new sentinels here as the domain grows.
+func HandleError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrInvalidInput):
+		WriteError(w, http.StatusBadRequest, err.Error())
+	case errors.Is(err, ErrNotFound):
+		WriteError(w, http.StatusNotFound, err.Error())
+	case errors.Is(err, ErrUnauthorized):
+		WriteError(w, http.StatusUnauthorized, err.Error())
+	case errors.Is(err, ErrInternal):
+		WriteError(w, http.StatusInternalServerError, "something went wrong")
+	default:
+		WriteError(w, http.StatusInternalServerError, "something went wrong")
+	}
+}

--- a/internal/handlers/app_handler.go
+++ b/internal/handlers/app_handler.go
@@ -1,8 +1,6 @@
 package handlers
 
 import (
-	"encoding/json"
-	"errors"
 	"net/http"
 
 	"github.com/opencrafts-io/verisafe/internal/core"
@@ -13,36 +11,10 @@ import (
 type AppHandler func(w http.ResponseWriter, r *http.Request) error
 
 // ServeHTTP implements http.Handler, adapting AppHandler into the standard library.
-// All error-to-HTTP mapping lives here — handlers never touch w.WriteHeader for errors.
+// All error-to-HTTP mapping lives in core.HandleError — handlers never touch
+// w.WriteHeader for errors.
 func (h AppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err := h(w, r); err != nil {
-		handleError(w, err)
+		core.HandleError(w, err)
 	}
-}
-
-// handleError maps domain errors to HTTP responses.
-// Add new sentinel errors here as the domain grows.
-func handleError(w http.ResponseWriter, err error) {
-	switch {
-	case errors.Is(err, core.ErrInvalidInput):
-		writeError(w, http.StatusBadRequest, err.Error())
-	case errors.Is(err, core.ErrNotFound):
-		writeError(w, http.StatusNotFound, err.Error())
-	case errors.Is(err, core.ErrUnauthorized):
-		writeError(w, http.StatusUnauthorized, err.Error())
-	case errors.Is(err, core.ErrInternal):
-		writeError(w, http.StatusInternalServerError, "something went wrong")
-	default:
-		writeError(w, http.StatusInternalServerError, "something went wrong")
-	}
-}
-
-func writeJSON(w http.ResponseWriter, status int, body any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(body)
-}
-
-func writeError(w http.ResponseWriter, status int, message string) {
-	writeJSON(w, status, map[string]string{"error": message})
 }

--- a/internal/handlers/device_handler.go
+++ b/internal/handlers/device_handler.go
@@ -83,6 +83,6 @@ func (dh *DeviceHandler) GetPersonalDevices(
 		return err
 	}
 
-	writeJSON(w, http.StatusOK, userDevices)
+	core.WriteJSON(w, http.StatusOK, userDevices)
 	return nil
 }


### PR DESCRIPTION
Per ADR 0003. Promotes writeJSON/writeError/handleError out of internal/handlers/app_handler.go into exported core.WriteJSON, core.WriteError, core.HandleError — core already owns the sentinel errors and core.APIError (the typed response body), and unlike the handlers package, it's importable from internal/auth.

internal/handlers/app_handler.go: AppHandler.ServeHTTP now delegates to core.HandleError instead of a local copy. device_handler.go's one external writeJSON call site updated to core.WriteJSON — same output, core.APIError serializes identically to the previous map[string]string{"error": ...}.

internal/auth/auth_handler.go: RefreshTokenHandler/RevokeTokenHandler/ ExchangeAuthCodeHandler needed no changes (already AppHandler-wrapped, inherit the shared behavior automatically). LoginHandler/CallbackHandler/ LogoutHandler's 14 http.Error(w, msg, status) call sites are mechanically replaced with core.WriteError(w, status, msg) — same status codes and messages, only the serialization changes from plain text to JSON. This is a deliberate wire-format change for these three handlers' error responses, evaluated and accepted (see ADR 0003) since they're OAuth redirect endpoints, not machine clients parsing error bodies as an API contract.

Verified with a local run against real Postgres/Redis/RabbitMQ: all
six /auth/* endpoints now return Content-Type: application/json with a
consistent {"error": "..."} body on error.